### PR TITLE
config.xml - Make compatible with limesurvey 6.0

### DIFF
--- a/plugin/config.xml
+++ b/plugin/config.xml
@@ -13,6 +13,7 @@
     </metadata>
 
     <compatibility>
+        <version>6.0</version>
         <version>5.0</version>
         <version>4.0</version>
         <version>3.0</version>


### PR DESCRIPTION
Bug: The RCE does not work with Limesurvey > 6.0 
with the message "the plugin is not compatible with your version of limesurvey"

Solution:
This adds a line in config.xml to make the webshell compatible with limesurvey version 6.0.

This has been tested on a [vulnlab](https://www.vulnlab.com/) machine and works as intendet.